### PR TITLE
fixed makefile to now representing the correct case of the referenced file

### DIFF
--- a/cypress/makefile
+++ b/cypress/makefile
@@ -1,4 +1,4 @@
-psoc := cy8c5xlp
+psoc := CY8C5XLP
 			
 Cypress_cy8c5xlp.lib : $(psoc:=.csv)
 	kipart $^ -r psoc5lp -b -s name -o $@ -w


### PR DESCRIPTION
Linux users were not able to compile the cypress library without this fix due to the filesystems case sensitivity